### PR TITLE
Update rc_init.c add support for kernel 6.11

### DIFF
--- a/src/rc_init.c
+++ b/src/rc_init.c
@@ -2791,7 +2791,9 @@ static struct ctl_table rcraid_table[] = {
 	  .mode		= 0644,
 	  .proc_handler	= &proc_dointvec
 	},
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6,11,0)
 	{ }
+#endif
 };
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(6,5,0)


### PR DESCRIPTION
Removing empty item in ctl_table.
Changes to kernel 6.11 in fs/proc/proc_sysctl.c throw an error when the ctl_table entry is empty (procname is null). As a result, the rcraid module causes “Kernel Panic!” and system hangs.